### PR TITLE
Update to robot framework fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name         = 'robotframework-zoomba',
       keywords     = 'Robot Framework',
       platforms    = 'any',
       install_requires= [
-          "robotframework>=3.0.2",
+          "robotframework==3.0.2",
           "robotframework-requests>=0.4.7",
           "robotframework-seleniumlibrary>=3.0.1",
           "robotframework-sudslibrary-aljcalandra",


### PR DESCRIPTION
The update to 3.0.3 in robotframework broke the dictionaries.  This will force it to 3.0.2 until we figure out the issue.